### PR TITLE
[compiler][ir] added forward declaration of `llvm::memoir::StructType…

### DIFF
--- a/compiler/passes/memoir/ir/Structs.hpp
+++ b/compiler/passes/memoir/ir/Structs.hpp
@@ -35,6 +35,7 @@ struct StructAllocInst;
 struct ReadInst;
 struct GetInst;
 struct StructGetInst;
+struct StructType;
 
 /*
  * Struct Summary


### PR DESCRIPTION
…` because the compiler was getting confused