### PR TITLE
Add RetPHI and Metadata for live-out values

### DIFF
--- a/compiler/memoir/ir/Builder.hpp
+++ b/compiler/memoir/ir/Builder.hpp
@@ -599,6 +599,14 @@ public:
     return this->create<DefPHIInst>(MemOIR_Func::DEF_PHI, { collection }, name);
   }
 
+  RetPHIInst *CreateRetPHI(llvm::Value *collection,
+                           llvm::Value *callee,
+                           const Twine &name = "") {
+    return this->create<RetPHIInst>(MemOIR_Func::RET_PHI,
+                                    { collection, callee },
+                                    name);
+  }
+
   // Type annotations.
   MemOIRInst *CreateAssertTypeInst(llvm::Value *object,
                                    Type &type,

--- a/compiler/memoir/ir/Instructions.hpp
+++ b/compiler/memoir/ir/Instructions.hpp
@@ -1331,10 +1331,6 @@ public:
   llvm::Value &getUsedCollection() const;
   llvm::Use &getUsedCollectionAsUse() const;
 
-  llvm::Instruction &getUseInst() const;
-  void setUseInst(llvm::Instruction &I) const;
-  void setUseInst(MemOIRInst &I) const;
-
   static bool classof(const MemOIRInst *I) {
     return (I->getKind() == MemOIR_Func::USE_PHI);
   };
@@ -1353,10 +1349,6 @@ public:
 
   llvm::Value &getDefinedCollection() const;
   llvm::Use &getDefinedCollectionAsUse() const;
-
-  llvm::Instruction &getDefInst() const;
-  void setDefInst(llvm::Instruction &I) const;
-  void setDefInst(MemOIRInst &I) const;
 
   static bool classof(const MemOIRInst *I) {
     return (I->getKind() == MemOIR_Func::DEF_PHI);

--- a/compiler/memoir/ir/Instructions.hpp
+++ b/compiler/memoir/ir/Instructions.hpp
@@ -1398,6 +1398,14 @@ public:
   llvm::Value &getInputCollection() const;
   llvm::Use &getInputCollectionAsUse() const;
 
+  /**
+   * @return the function called, or NULL if it was an indirect function
+   * invocation.
+   */
+  llvm::Function *getCalledFunction() const;
+  llvm::Value &getCalledOperand() const;
+  llvm::Use &getCalledOperandAsUse() const;
+
   // TODO: add methods for decoding the metadata.
 
   static bool classof(const MemOIRInst *I) {

--- a/compiler/memoir/ir/src/Instructions/SSAInsts.cpp
+++ b/compiler/memoir/ir/src/Instructions/SSAInsts.cpp
@@ -7,57 +7,15 @@
 
 namespace llvm::memoir {
 
-/*
- * UsePHIInst implementation
- */
+// UsePHIInst implementation
 RESULTANT(UsePHIInst, ResultCollection)
 OPERAND(UsePHIInst, UsedCollection, 0)
-
-llvm::Instruction &UsePHIInst::getUseInst() const {
-  // Look for metadata attached to this use.
-  auto *value = MetadataManager::getMetadata(this->getCallInst(),
-                                             MetadataType::MD_USE_PHI);
-  auto *inst = dyn_cast_or_null<llvm::Instruction>(value);
-  MEMOIR_NULL_CHECK(inst, "Couldn't get the UseInst");
-  return *inst;
-}
-
-void UsePHIInst::setUseInst(llvm::Instruction &I) const {
-  // Update this information in the MetadataManager
-  MetadataManager::setMetadata(this->getCallInst(),
-                               MetadataType::MD_USE_PHI,
-                               &I);
-}
-
-void UsePHIInst::setUseInst(MemOIRInst &I) const {
-  this->setUseInst(I.getCallInst());
-}
 
 TO_STRING(UsePHIInst)
 
 // DefPHIInst implementation
 RESULTANT(DefPHIInst, ResultCollection)
 OPERAND(DefPHIInst, DefinedCollection, 0)
-
-llvm::Instruction &DefPHIInst::getDefInst() const {
-  // Look for metadata attached to this definition.
-  auto *value = MetadataManager::getMetadata(this->getCallInst(),
-                                             MetadataType::MD_DEF_PHI);
-  auto *inst = dyn_cast_or_null<llvm::Instruction>(value);
-  MEMOIR_NULL_CHECK(inst, "Couldn't get the DefInst");
-  return *inst;
-}
-
-void DefPHIInst::setDefInst(llvm::Instruction &I) const {
-  // Update this information in the MetadataManager
-  MetadataManager::setMetadata(this->getCallInst(),
-                               MetadataType::MD_DEF_PHI,
-                               &I);
-}
-
-void DefPHIInst::setDefInst(MemOIRInst &I) const {
-  this->setDefInst(I.getCallInst());
-}
 
 TO_STRING(DefPHIInst)
 

--- a/compiler/memoir/ir/src/Instructions/SSAInsts.cpp
+++ b/compiler/memoir/ir/src/Instructions/SSAInsts.cpp
@@ -70,6 +70,12 @@ TO_STRING(ArgPHIInst)
 // RetPHIInst implementation
 RESULTANT(RetPHIInst, ResultCollection)
 OPERAND(RetPHIInst, InputCollection, 0)
+
+llvm::Function *RetPHIInst::getCalledFunction() const {
+  return dyn_cast<llvm::Function>(&this->getCalledOperand());
+}
+
+OPERAND(RetPHIInst, CalledOperand, 1)
 // TODO: implement metadata for storing the incoming collections.
 TO_STRING(RetPHIInst)
 

--- a/compiler/memoir/ir/src/TypeCheck.cpp
+++ b/compiler/memoir/ir/src/TypeCheck.cpp
@@ -323,6 +323,7 @@ Type *TypeChecker::visitSequenceAllocInst(SequenceAllocInst &I) {
 
 // Reference Read Instructions.
 Type *TypeChecker::visitReadInst(ReadInst &I) {
+
   // Get the collection type being accessed.
   auto *object_type = this->analyze(I.getObjectOperand());
   auto &collection_type =
@@ -643,14 +644,18 @@ Type *TypeChecker::unify(Type *t, Type *u) {
     return t;
   }
 
-  if (auto *tvar = dyn_cast<TypeVariable>(t)) {
-    this->type_bindings[tvar] = u;
-    return u;
+  if (t != nullptr) {
+    if (auto *tvar = dyn_cast<TypeVariable>(t)) {
+      this->type_bindings[tvar] = u;
+      return u;
+    }
   }
 
-  if (auto *uvar = dyn_cast<TypeVariable>(u)) {
-    this->type_bindings[uvar] = t;
-    return t;
+  if (u != nullptr) {
+    if (auto *uvar = dyn_cast<TypeVariable>(u)) {
+      this->type_bindings[uvar] = t;
+      return t;
+    }
   }
 
   // If neither t nor u is a type variable, and they are not equal, we have a

--- a/compiler/memoir/ir/src/Types.cpp
+++ b/compiler/memoir/ir/src/Types.cpp
@@ -360,7 +360,11 @@ bool Type::is_collection_type(Type &type) {
 }
 
 bool Type::value_is_collection_type(llvm::Value &value) {
-  if (not isa<llvm::Instruction>(&value) && not isa<llvm::Argument>(&value)) {
+  if (not isa<llvm::PointerType>(value.getType())) {
+    return false;
+  }
+
+  if (not isa<llvm::Instruction>(&value) and not isa<llvm::Argument>(&value)) {
     return false;
   }
 
@@ -368,7 +372,11 @@ bool Type::value_is_collection_type(llvm::Value &value) {
 }
 
 bool Type::value_is_struct_type(llvm::Value &value) {
-  if (not isa<llvm::Instruction>(&value) && not isa<llvm::Argument>(&value)) {
+  if (not isa<llvm::PointerType>(value.getType())) {
+    return false;
+  }
+
+  if (not isa<llvm::Instruction>(&value) and not isa<llvm::Argument>(&value)) {
     return false;
   }
 

--- a/compiler/memoir/ir/src/Verifier.cpp
+++ b/compiler/memoir/ir/src/Verifier.cpp
@@ -1,6 +1,7 @@
 // LLVM
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/CFG.h"
+#include "llvm/IR/Value.h"
 
 // MEMOIR
 #include "memoir/passes/Passes.hpp"
@@ -231,10 +232,10 @@ bool verify_linearity(llvm::Function &F, LivenessResult &LR) {
     for (auto *succ : llvm::successors(&BB)) {
       auto &Succ = MEMOIR_SANITIZE(succ, "Successor of BasicBlock is NULL!");
       if (not check_basic_block_edge(LR, partition, BB, Succ)) {
-        println("  at edge from ",
-                BB.getNameOrAsOperand(),
-                " to ",
-                Succ.getNameOrAsOperand());
+        println("  at edge from ");
+        BB.printAsOperand(llvm::errs(), false);
+        println(" to ");
+        Succ.printAsOperand(llvm::errs(), false);
         return false;
       }
     }

--- a/compiler/memoir/transforms/CMakeLists.txt
+++ b/compiler/memoir/transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ function(add_memoir_transform name)
 endfunction()
 
 # Core.
+add_subdirectory(utilities)
 add_subdirectory(normalization)
 add_subdirectory(ssa_construction)
 add_subdirectory(ssa_destruction)

--- a/compiler/memoir/transforms/ssa_construction/src/Pass.cpp
+++ b/compiler/memoir/transforms/ssa_construction/src/Pass.cpp
@@ -281,8 +281,9 @@ llvm::PreservedAnalyses SSAConstructionPass::run(
       debugln(*bb);
       for (auto *succ_bb : llvm::successors(bb)) {
         for (auto &phi : succ_bb->phis()) {
+
           // Ensure that the value is of collection type.
-          if (not isa_and_nonnull<CollectionType>(type_of(phi))) {
+          if (not Type::value_is_collection_type(phi)) {
             continue;
           }
 

--- a/compiler/memoir/transforms/ssa_construction/src/SSAConstructionVisitor.hpp
+++ b/compiler/memoir/transforms/ssa_construction/src/SSAConstructionVisitor.hpp
@@ -34,11 +34,14 @@ public:
   // LLVM operations
   void visitInstruction(llvm::Instruction &I);
   void visitPHINode(llvm::PHINode &I);
+  void visitLLVMCallInst(llvm::CallInst &I);
+  void visitReturnInst(llvm::ReturnInst &I);
   // SSA operations
   void visitUsePHIInst(UsePHIInst &I);
   void visitDefPHIInst(DefPHIInst &I);
   void visitArgPHIInst(ArgPHIInst &I);
   void visitRetPHIInst(RetPHIInst &I);
+  void visitFoldInst(FoldInst &I);
   // Access operations
   void visitMutStructWriteInst(MutStructWriteInst &I);
   void visitMutIndexWriteInst(MutIndexWriteInst &I);

--- a/compiler/memoir/transforms/utilities/CMakeLists.txt
+++ b/compiler/memoir/transforms/utilities/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB sources "src/*.cpp")
+
+add_memoir_sources(
+  FILES
+  ${sources}
+)

--- a/compiler/memoir/transforms/utilities/Inlining.hpp
+++ b/compiler/memoir/transforms/utilities/Inlining.hpp
@@ -1,0 +1,21 @@
+#ifndef MEMOIR_TRANSFORMS_UTILITIES_INLINER_H
+#define MEMOIR_TRANSFORMS_UTILITIES_INLINER_H
+
+#include "llvm/Transforms/Utils/Cloning.h"
+
+namespace llvm::memoir {
+
+/**
+ * A wrapper for LLVM's InlineFunction call.
+ * Re-maps arguments to their live-out variable.
+ */
+llvm::InlineResult InlineFunction(llvm::CallBase &CB,
+                                  llvm::InlineFunctionInfo &IFI,
+                                  bool MergeAttributes = false,
+                                  llvm::AAResults *CalleeAAR = nullptr,
+                                  bool InsertLifetime = true,
+                                  llvm::Function *ForwardArgsTo = nullptr);
+
+} // namespace llvm::memoir
+
+#endif // MEMOIR_TRANSFORMS_UTILITIES_INLINER_H

--- a/compiler/memoir/transforms/utilities/src/Inlining.cpp
+++ b/compiler/memoir/transforms/utilities/src/Inlining.cpp
@@ -1,0 +1,212 @@
+// LLVM
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+// MEMOIR
+#include "memoir/transforms/utilities/Inlining.hpp"
+
+#include "memoir/ir/Instructions.hpp"
+
+#include "memoir/support/Casting.hpp"
+#include "memoir/support/Print.hpp"
+
+#include "memoir/utility/Metadata.hpp"
+
+namespace llvm::memoir {
+
+/**
+ * Helper function to collect the set of basic blocks between the start and end
+ * block. This function assumes that start and end are the entry and exit of an
+ * SESE region.
+ *
+ * @param blocks the set of basic blocks that will be populated with the basic
+ *               blocks in the region, not including entry and exit
+ * @param entry a reference to the single-entry
+ * @param exit a reference to the single-exit
+ */
+void collect_blocks_between(set<llvm::BasicBlock *> &blocks,
+                            llvm::BasicBlock &entry,
+                            llvm::BasicBlock &exit) {
+  vector<llvm::BasicBlock *> worklist = { &entry };
+  while (not worklist.empty()) {
+    // Pop off the top block of the worklist.
+    auto *current = worklist.back();
+    worklist.pop_back();
+
+    // For each successor, add it to the set of blocks:
+    for (auto *successor : llvm::successors(current)) {
+      // Sanity check that the basic block is non-NULL.
+      if (successor == nullptr) {
+        continue;
+      }
+
+      // If the block is the entry or exit, skip it.
+      if (successor == &entry or successor == &exit) {
+        continue;
+      }
+
+      // If the block is already in the set of blocks, skip it.
+      if (blocks.count(successor) > 0) {
+        continue;
+      }
+
+      // Otherwise, add it to the set and the worklist.
+      blocks.insert(successor);
+      worklist.push_back(successor);
+    }
+  }
+  return;
+}
+
+llvm::InlineResult InlineFunction(llvm::CallBase &CB,
+                                  llvm::InlineFunctionInfo &IFI,
+                                  bool merge_attributes,
+                                  llvm::AAResults *callee_aa_results,
+                                  bool insert_lifetime,
+                                  llvm::Function *forward_args_to) {
+
+  // Split the call into its own basic block.
+  auto *block = CB.getParent();
+  auto *entry =
+      llvm::SplitBlock(block,
+                       &CB,
+                       /* DomTreeUpdater = */ (llvm::DomTreeUpdater *)nullptr,
+                       /* LoopInfo = */ nullptr,
+                       /* MemorySSAUpdater = */ nullptr,
+                       /* BBName = */ "inline.entry.",
+                       /* Before = */ true);
+
+  auto *exit =
+      llvm::SplitBlock(block,
+                       CB.getNextNode(),
+                       /* DomTreeUpdater = */ (llvm::DomTreeUpdater *)nullptr,
+                       /* LoopInfo = */ nullptr,
+                       /* MemorySSAUpdater = */ nullptr,
+                       /* BBName = */ "inline.exit.",
+                       /* Before = */ false);
+
+  // Save the function operand for later.
+  auto *callee = CB.getCalledOperand();
+
+  // Collect all of the collection arguments to the function before we inline
+  // the function.
+  unsigned arg_index = 0;
+  map<unsigned, llvm::Value *> arguments_to_patch = {};
+  for (auto &arg_use : CB.data_ops()) {
+
+    // Unpack the argument value.
+    auto *arg = arg_use.get();
+
+    // If the argument is a collection, add it to the mapping.
+    if (Type::value_is_collection_type(*arg)) {
+      arguments_to_patch[arg_index] = arg;
+    }
+
+    // Increment the argument index.
+    ++arg_index;
+  }
+
+  // Inline the function at the call site.
+  auto result = llvm::InlineFunction(CB,
+                                     IFI,
+                                     merge_attributes,
+                                     callee_aa_results,
+                                     insert_lifetime,
+                                     forward_args_to);
+
+  // If we did not a succeed, return now.
+  if (not result.isSuccess()) {
+    return result;
+  }
+
+  // If there are no arguments to patch, return now.
+  if (arguments_to_patch.empty()) {
+    return result;
+  }
+
+  // Collect the set of basic blocks introduced by inlining.
+  set<llvm::BasicBlock *> inlined_blocks = {};
+  collect_blocks_between(inlined_blocks, *entry, *exit);
+
+  // Otherwise, we need to traverse the CFG of the newly inlined function to
+  // find any instructions with LiveOutMetadata attached.
+  map<llvm::Value *, llvm::Value *> patches = {};
+  for (auto *inlined_block : inlined_blocks) {
+    for (auto &I : *inlined_block) {
+      // Check if this instruction has live-out metadata.
+      auto live_out_metadata = Metadata::get<LiveOutMetadata>(I);
+
+      // If it doesn't, skip it.
+      if (not live_out_metadata.has_value()) {
+        continue;
+      }
+
+      // Otherwise, get the corresponding argument.
+      auto arg_number = live_out_metadata->getArgNo();
+      if (arguments_to_patch.count(arg_number) == 0) {
+        MEMOIR_UNREACHABLE(
+            "LiveOutMetadata has invalid/stale argument number.");
+      }
+      auto *argument = arguments_to_patch[arg_number];
+
+      // Record the patch.
+      if (patches.count(argument) > 0) {
+        MEMOIR_UNREACHABLE(
+            "Argument of inlined function has multiple live-outs."
+            "The function had more than one ReturnInst!");
+      }
+      patches[argument] = &I;
+
+      // Remove the old metadata.
+      Metadata::remove<LiveOutMetadata>(I);
+    }
+  }
+
+  // Find all relevant RetPHIs.
+  set<llvm::Instruction *> to_cleanup = {};
+  for (const auto &[to_patch, patch] : patches) {
+
+    // For each use of the value to patch:
+    for (auto &use : to_patch->uses()) {
+      // Get the user information.
+      auto *user = use.getUser();
+      auto *user_as_inst = dyn_cast<llvm::Instruction>(user);
+
+      // Skip non-instruction users.
+      if (not user_as_inst) {
+        continue;
+      }
+
+      // FIXME: this implementation assumes that there are no other calls to the
+      // same function, it needs to be extended with dominance information
+      // (checking that the RetPHI is dominated by the patch).
+
+      // If the instruction is a RetPHI, add it to the set if it is for the same
+      // callee.
+      if (auto *ret_phi = into<RetPHIInst>(*user_as_inst)) {
+
+        // Check that the callee is the same.
+        if (&ret_phi->getCalledOperand() != callee) {
+          continue;
+        }
+
+        // Get the input collection.
+        auto &input = ret_phi->getInputCollection();
+
+        // Replace uses of the RetPHI with the patch.
+        ret_phi->getResultCollection().replaceAllUsesWith(patch);
+
+        // Mark the RetPHI for cleanup.
+        to_cleanup.insert(&ret_phi->getCallInst());
+      }
+    }
+  }
+
+  // Erase the old RetPHIs.
+  for (auto *cleanup : to_cleanup) {
+    cleanup->eraseFromParent();
+  }
+
+  return result;
+}
+
+} // namespace llvm::memoir

--- a/compiler/memoir/utility/Metadata.def
+++ b/compiler/memoir/utility/Metadata.def
@@ -1,0 +1,5 @@
+/* METADATA(ENUM, STR) */
+
+METADATA(MD_LIVE_OUT, "memoir.live-out", LiveOutMetadata)
+
+#undef METADATA

--- a/compiler/memoir/utility/Metadata.hpp
+++ b/compiler/memoir/utility/Metadata.hpp
@@ -61,33 +61,21 @@ public:
   LiveOutMetadata(llvm::MDTuple &md) : Metadata(md) {}
 
   /**
-   * @return the number of live out values.
-   */
-  unsigned getNumLiveOuts() const;
-
-  /**
-   * @return the LLVM Value corresponding to the argument passed into the
-   * function.
-   */
-  llvm::Value &getArgument(unsigned i) const;
-  llvm::Metadata &getArgumentMD(unsigned i) const;
-  const llvm::MDOperand &getArgumentMDOperand(unsigned i) const;
-
-  /**
-   * @param i get the i'th live out.
-   * @return the live out LLVM Value of the function.
-   */
-  llvm::Value &getLiveOut(unsigned i) const;
-  llvm::Metadata &getLiveOutMD(unsigned i) const;
-  const llvm::MDOperand &getLiveOutMDOperand(unsigned i) const;
-
-  /**
-   * Add an Argument-LiveOut pair to the metadata.
+   * Get the corresponding argument number that is a live-out for.
+   * NOTE: this assumes a single ReturnInst for each LLVM Function.
    *
-   * @param argument the argument that has a live-out.
-   * @param live_out the live-out value.
+   * @return the argument number
    */
-  void addLiveOut(llvm::Value &argument, llvm::Value &live_out) const;
+  unsigned getArgNo() const;
+  llvm::Metadata &getArgNoMD() const;
+  const llvm::MDOperand &getArgNoMDOperand() const;
+
+  /**
+   * Set the argument number.
+   *
+   * @param argument_number the argument number
+   */
+  void setArgNo(unsigned argument_number);
 };
 
 } // namespace llvm::memoir

--- a/compiler/memoir/utility/MetadataUtils.hpp
+++ b/compiler/memoir/utility/MetadataUtils.hpp
@@ -1,0 +1,29 @@
+#include "memoir/utility/Metadata.hpp"
+
+#define OPERAND(CLASS, NAME, OP_NUM)                                           \
+  llvm::Metadata &CLASS::get##NAME##MD() const {                               \
+    return *(this->get##NAME##MDOperand().get());                              \
+  }                                                                            \
+  const llvm::MDOperand &CLASS::get##NAME##MDOperand() const {                 \
+    return this->getMetadata().getOperand(OP_NUM);                             \
+  }
+
+#define VALUE_OPERAND(CLASS, NAME, OP_NUM)                                     \
+  llvm::Value &CLASS::get##NAME() const {                                      \
+    auto &metadata = this->getArgumentMD();                                    \
+    auto &value_as_metadata =                                                  \
+        MEMOIR_SANITIZE( \ 
+      dyn_cast<llvm::ValueAsMetadata>(&argument_metadata),                     \
+                         #NAME " operand of " #CLASS                           \
+                               " is not a ValueAsMetadata");                   \
+    auto &value =                                                              \
+        MEMOIR_SANITIZE(argument_value_as_metadata.getValue(),                 \
+                        #NAME " operand of " #CLASS " is a NULL value!");      \
+    return value;                                                              \
+  }                                                                            \
+  llvm::MDNode &CLASS::get##NAME##MD() const {                                 \
+    return *(this->get##NAME##MDOperand().get());                              \
+  }                                                                            \
+  const llvm::MDOperand &CLASS::get##NAME##MDOperand() const {                 \
+    return this->getMetadata().getOperand(OP_NUM);                             \
+  }

--- a/compiler/memoir/utility/src/LiveOutMetadata.cpp
+++ b/compiler/memoir/utility/src/LiveOutMetadata.cpp
@@ -1,0 +1,65 @@
+#include "memoir/utility/Metadata.hpp"
+
+#include "memoir/support/Casting.hpp"
+
+namespace llvm::memoir {
+
+unsigned LiveOutMetadata::getNumLiveOuts() const {
+  auto num_operands = this->getMetadata().getNumOperands();
+  MEMOIR_ASSERT(num_operands % 2 == 0, "Malformed LiveOutMetadata!");
+  return num_operands / 2;
+}
+
+llvm::Value &LiveOutMetadata::getArgument(unsigned i) const {
+  auto &metadata = this->getArgumentMD(i);
+  auto &value_as_metadata = MEMOIR_SANITIZE(
+      dyn_cast<llvm::ValueAsMetadata>(&metadata),
+      "Argument operand of LiveOutMetadata is not a ValueAsMetadata");
+  auto &value =
+      MEMOIR_SANITIZE(value_as_metadata.getValue(),
+                      "Argument operand of LiveOutMetadata is a NULL value!");
+  return value;
+}
+
+llvm::Metadata &LiveOutMetadata::getArgumentMD(unsigned i) const {
+  return *(this->getArgumentMDOperand(i).get());
+}
+
+const llvm::MDOperand &LiveOutMetadata::getArgumentMDOperand(unsigned i) const {
+  return this->getMetadata().getOperand(2 * i);
+}
+
+llvm::Value &LiveOutMetadata::getLiveOut(unsigned i) const {
+  auto &metadata = this->getLiveOutMD(i);
+  auto &value_as_metadata = MEMOIR_SANITIZE(
+      dyn_cast<llvm::ValueAsMetadata>(&metadata),
+      "LiveOut operand of LiveOutMetadata is not a ValueAsMetadata");
+  auto &value =
+      MEMOIR_SANITIZE(value_as_metadata.getValue(),
+                      "LiveOut operand of LiveOutMetadata is a NULL value!");
+  return value;
+}
+
+llvm::Metadata &LiveOutMetadata::getLiveOutMD(unsigned i) const {
+  return *(this->getLiveOutMDOperand(i).get());
+}
+
+const llvm::MDOperand &LiveOutMetadata::getLiveOutMDOperand(unsigned i) const {
+  return this->getMetadata().getOperand(2 * i);
+}
+
+void LiveOutMetadata::addLiveOut(llvm::Value &argument,
+                                 llvm::Value &live_out) const {
+  // Construct the values as metadata.
+  auto *argument_metadata = llvm::ValueAsMetadata::get(&argument);
+  auto *live_out_metadata = llvm::ValueAsMetadata::get(&live_out);
+
+  // Append to the MDTuple.
+  auto &md_tuple = this->getMetadata();
+  md_tuple.push_back(argument_metadata);
+  md_tuple.push_back(live_out_metadata);
+
+  return;
+}
+
+} // namespace llvm::memoir

--- a/compiler/memoir/utility/src/LiveOutMetadata.cpp
+++ b/compiler/memoir/utility/src/LiveOutMetadata.cpp
@@ -1,65 +1,49 @@
+#include "llvm/IR/Constants.h"
+
 #include "memoir/utility/Metadata.hpp"
+#include "memoir/utility/MetadataUtils.hpp"
 
 #include "memoir/support/Casting.hpp"
 
 namespace llvm::memoir {
 
-unsigned LiveOutMetadata::getNumLiveOuts() const {
-  auto num_operands = this->getMetadata().getNumOperands();
-  MEMOIR_ASSERT(num_operands % 2 == 0, "Malformed LiveOutMetadata!");
-  return num_operands / 2;
+unsigned LiveOutMetadata::getArgNo() const {
+  // Fetch the metadata.
+  auto &metadata = this->getArgNoMD();
+  auto &constant_as_metadata = MEMOIR_SANITIZE(
+      dyn_cast<llvm::ConstantAsMetadata>(&metadata),
+      "Malformed LiveOutMetadata, expected an llvm::ConstantAsMetadata");
+
+  // Unpack the argument number from the metadata.
+  auto *constant = constant_as_metadata.getValue();
+  auto &constant_int = MEMOIR_SANITIZE(
+      dyn_cast_or_null<llvm::ConstantInt>(constant),
+      "Malformed LiveOutMetadata, expected an llvm::ConstantInt");
+  auto arg_number = unsigned(constant_int.getZExtValue());
+
+  return arg_number;
 }
 
-llvm::Value &LiveOutMetadata::getArgument(unsigned i) const {
-  auto &metadata = this->getArgumentMD(i);
-  auto &value_as_metadata = MEMOIR_SANITIZE(
-      dyn_cast<llvm::ValueAsMetadata>(&metadata),
-      "Argument operand of LiveOutMetadata is not a ValueAsMetadata");
-  auto &value =
-      MEMOIR_SANITIZE(value_as_metadata.getValue(),
-                      "Argument operand of LiveOutMetadata is a NULL value!");
-  return value;
+void LiveOutMetadata::setArgNo(unsigned arg_number) {
+  // Fetch relevant information.
+  auto &metadata = this->getMetadata();
+  auto &context = metadata.getContext();
+
+  // Create a constant for the argument number.
+  auto *unsigned_type = llvm::IntegerType::get(context, 8);
+  auto *arg_number_constant = llvm::ConstantInt::get(unsigned_type, arg_number);
+
+  // Create a metadata wrapper.
+  auto *arg_number_metadata =
+      llvm::ConstantAsMetadata::get(arg_number_constant);
+
+  // Append the metadata.
+  if (metadata.getNumOperands() == 1) {
+    metadata.pop_back();
+  }
+  metadata.push_back(arg_number_metadata);
 }
 
-llvm::Metadata &LiveOutMetadata::getArgumentMD(unsigned i) const {
-  return *(this->getArgumentMDOperand(i).get());
-}
-
-const llvm::MDOperand &LiveOutMetadata::getArgumentMDOperand(unsigned i) const {
-  return this->getMetadata().getOperand(2 * i);
-}
-
-llvm::Value &LiveOutMetadata::getLiveOut(unsigned i) const {
-  auto &metadata = this->getLiveOutMD(i);
-  auto &value_as_metadata = MEMOIR_SANITIZE(
-      dyn_cast<llvm::ValueAsMetadata>(&metadata),
-      "LiveOut operand of LiveOutMetadata is not a ValueAsMetadata");
-  auto &value =
-      MEMOIR_SANITIZE(value_as_metadata.getValue(),
-                      "LiveOut operand of LiveOutMetadata is a NULL value!");
-  return value;
-}
-
-llvm::Metadata &LiveOutMetadata::getLiveOutMD(unsigned i) const {
-  return *(this->getLiveOutMDOperand(i).get());
-}
-
-const llvm::MDOperand &LiveOutMetadata::getLiveOutMDOperand(unsigned i) const {
-  return this->getMetadata().getOperand(2 * i);
-}
-
-void LiveOutMetadata::addLiveOut(llvm::Value &argument,
-                                 llvm::Value &live_out) const {
-  // Construct the values as metadata.
-  auto *argument_metadata = llvm::ValueAsMetadata::get(&argument);
-  auto *live_out_metadata = llvm::ValueAsMetadata::get(&live_out);
-
-  // Append to the MDTuple.
-  auto &md_tuple = this->getMetadata();
-  md_tuple.push_back(argument_metadata);
-  md_tuple.push_back(live_out_metadata);
-
-  return;
-}
+OPERAND(LiveOutMetadata, ArgNo, 0)
 
 } // namespace llvm::memoir

--- a/compiler/memoir/utility/src/Metadata.cpp
+++ b/compiler/memoir/utility/src/Metadata.cpp
@@ -33,7 +33,8 @@ std::string get_metadata_tag(MetadataKind kind) {
     auto &context = F.getContext();                                            \
     auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
     auto *metadata =                                                           \
-        llvm::MDTuple::get(context, llvm::ArrayRef<llvm::Metadata *>({}));     \
+        llvm::MDTuple::getDistinct(context,                                    \
+                                   llvm::ArrayRef<llvm::Metadata *>({}));      \
     F.setMetadata(tag, metadata);                                              \
     return CLASS(*metadata);                                                   \
   }                                                                            \
@@ -62,7 +63,8 @@ std::string get_metadata_tag(MetadataKind kind) {
     auto &context = I.getContext();                                            \
     auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
     auto *metadata =                                                           \
-        llvm::MDTuple::get(context, llvm::ArrayRef<llvm::Metadata *>({}));     \
+        llvm::MDTuple::getDistinct(context,                                    \
+                                   llvm::ArrayRef<llvm::Metadata *>({}));      \
     I.setMetadata(tag, metadata);                                              \
     return CLASS(*metadata);                                                   \
   }                                                                            \

--- a/compiler/memoir/utility/src/Metadata.cpp
+++ b/compiler/memoir/utility/src/Metadata.cpp
@@ -1,446 +1,81 @@
 #include "memoir/utility/Metadata.hpp"
 
-#include "memoir/support/Assert.hpp"
+namespace llvm::memoir {
 
-namespace llvm {
-namespace memoir {
-
-// Static entry points.
-void MetadataManager::setMetadata(llvm::Function &F, MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.setMetadata(F, mdKind);
-
-  return;
-}
-
-void MetadataManager::setMetadata(llvm::Function &F,
-                                  MetadataType MT,
-                                  llvm::Value *value) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.setMetadata(F, mdKind, value);
-
-  return;
-}
-
-bool MetadataManager::hasMetadata(llvm::Function &F, MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  return MM.hasMetadata(F, mdKind);
-}
-
-void MetadataManager::insertMetadata(llvm::Function &F,
-                                     MetadataType MT,
-                                     std::string str) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.insertMetadata(F, mdKind, str);
-
-  return;
-}
-
-void MetadataManager::removeMetadata(llvm::Function &F,
-                                     MetadataType MT,
-                                     std::string str) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.removeMetadata(F, mdKind, str);
-
-  return;
-}
-
-llvm::Value *MetadataManager::getMetadata(llvm::Function &F, MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  return MM.getMetadata(F, mdKind);
-}
-
-void MetadataManager::setMetadata(llvm::Instruction &I, MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.setMetadata(I, mdKind);
-
-  return;
-}
-
-void MetadataManager::setMetadata(llvm::Instruction &I,
-                                  MetadataType MT,
-                                  llvm::Value *value) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.setMetadata(I, mdKind, value);
-
-  return;
-}
-
-bool MetadataManager::hasMetadata(llvm::Instruction &I, MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  return MM.hasMetadata(I, mdKind);
-}
-
-void MetadataManager::insertMetadata(llvm::Instruction &I,
-                                     MetadataType MT,
-                                     std::string str) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.insertMetadata(I, mdKind, str);
-
-  return;
-}
-
-void MetadataManager::removeMetadata(llvm::Instruction &I,
-                                     MetadataType MT,
-                                     std::string str) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  MM.removeMetadata(I, mdKind, str);
-
-  return;
-}
-
-llvm::Value *MetadataManager::getMetadata(llvm::Instruction &I,
-                                          MetadataType MT) {
-  auto &MM = MetadataManager::getManager();
-
-  auto mdKind = MM.MDtoString[MT];
-
-  return MM.getMetadata(I, mdKind);
-}
-
-// Private and internal methods
-
-//// Function metadata.
-void MetadataManager::setMetadata(llvm::Function &F, std::string kind) {
-  /*
-   * Create the metadata
-   */
-  auto &Context = F.getContext();
-  auto mdString = llvm::MDString::get(Context, kind);
-  auto mdNode =
-      llvm::MDNode::get(Context, ArrayRef<llvm::Metadata *>({ mdString }));
-
-  /*
-   * Attach the metadata to the function
-   */
-  F.setMetadata(kind, mdNode);
-
-  return;
-}
-
-void MetadataManager::setMetadata(llvm::Function &F,
-                                  std::string kind,
-                                  llvm::Value *value) {
-  /*
-   * Create the metadata
-   */
-  auto &Context = F.getContext();
-  auto *mdString = llvm::MDString::get(Context, kind);
-  auto *mdValue = llvm::ValueAsMetadata::get(value);
-  auto *mdNode =
-      llvm::MDNode::get(Context,
-                        ArrayRef<llvm::Metadata *>({ mdString, mdValue }));
-
-  /*
-   * Attach the metadata to the function
-   */
-  F.setMetadata(kind, mdNode);
-
-  return;
-}
-
-void MetadataManager::insertMetadata(llvm::Function &F,
-                                     std::string kind,
-                                     std::string value) {
-  // Get the context.
-  auto &Context = F.getContext();
-
-  // Get the current metadata node.
-  auto *current_md = F.getMetadata(kind);
-
-  // If there isn't a metadata there yet, create it.
-  if (current_md == nullptr) {
-    auto *md_string = llvm::MDString::get(Context, value);
-    auto *md_tuple =
-        llvm::MDTuple::getDistinct(Context,
-                                   ArrayRef<llvm::Metadata *>(md_string));
-    F.setMetadata(kind, md_tuple);
-    return;
+std::string get_metadata_tag(MetadataKind kind) {
+  switch (kind) {
+#define METADATA(ENUM, STR, CLASS)                                             \
+  case MetadataKind::ENUM:                                                     \
+    return STR;
+#include "memoir/utility/Metadata.def"
+    default:
+      return "";
   }
-
-  // Otherwise, search the tuple for the key we are inserting.
-  auto &current_md_tuple =
-      MEMOIR_SANITIZE(dyn_cast<llvm::MDTuple>(current_md),
-                      "Trying the insert metadata to a non-tuple Metadata");
-  for (auto &operand : current_md_tuple.operands()) {
-    auto *operand_md = operand.get();
-    auto *operand_md_string = dyn_cast_or_null<llvm::MDString>(operand_md);
-    MEMOIR_NULL_CHECK(operand_md_string, "MDTuple contains non-MDString");
-    if (operand_md_string->getString().str() == value) {
-      return;
-    }
-  }
-
-  // If we didn't find the key, create and push the metadata onto the tuple.
-  auto *md_string = llvm::MDString::get(Context, value);
-  vector<llvm::Metadata *> new_operands(current_md_tuple.op_begin(),
-                                        current_md_tuple.op_end());
-  new_operands.push_back(md_string);
-  auto *new_md_tuple = llvm::MDTuple::getDistinct(Context, new_operands);
-  F.setMetadata(kind, new_md_tuple);
-
-  return;
 }
 
-void MetadataManager::removeMetadata(llvm::Function &F,
-                                     std::string kind,
-                                     std::string value) {
-  // Get the context.
-  auto &Context = F.getContext();
-
-  // Get the current metadata node.
-  auto *current_md = F.getMetadata(kind);
-
-  // If there isn't a metadata there yet, we're done.
-  if (current_md == nullptr) {
-    return;
+#define METADATA(ENUM, STR, CLASS)                                             \
+  template <>                                                                  \
+  std::optional<CLASS> Metadata::get(llvm::Function &F) {                      \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    if (not F.hasMetadata(tag)) {                                              \
+      return std::nullopt;                                                     \
+    }                                                                          \
+    auto *metadata = dyn_cast_or_null<llvm::MDTuple>(F.getMetadata(tag));      \
+    return (metadata == nullptr) ? std::nullopt                                \
+                                 : std::make_optional(CLASS(*metadata));       \
+  }                                                                            \
+  template <>                                                                  \
+  CLASS Metadata::get_or_add<CLASS>(llvm::Function & F) {                      \
+    auto got = Metadata::get<CLASS>(F);                                        \
+    if (got.has_value()) {                                                     \
+      return got.value();                                                      \
+    }                                                                          \
+    auto &context = F.getContext();                                            \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    auto *metadata =                                                           \
+        llvm::MDTuple::get(context, llvm::ArrayRef<llvm::Metadata *>({}));     \
+    F.setMetadata(tag, metadata);                                              \
+    return CLASS(*metadata);                                                   \
+  }                                                                            \
+  template <>                                                                  \
+  bool Metadata::remove<CLASS>(llvm::Function & F) {                           \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    F.setMetadata(tag, nullptr);                                               \
+    return true;                                                               \
+  }                                                                            \
+  template <>                                                                  \
+  std::optional<CLASS> Metadata::get<CLASS>(llvm::Instruction & I) {           \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    if (not I.hasMetadata(tag)) {                                              \
+      return std::nullopt;                                                     \
+    }                                                                          \
+    auto *metadata = dyn_cast_or_null<llvm::MDTuple>(I.getMetadata(tag));      \
+    return (metadata == nullptr) ? std::nullopt                                \
+                                 : std::make_optional(CLASS(*metadata));       \
+  }                                                                            \
+  template <>                                                                  \
+  CLASS Metadata::get_or_add<CLASS>(llvm::Instruction & I) {                   \
+    auto got = Metadata::get<CLASS>(I);                                        \
+    if (got.has_value()) {                                                     \
+      return got.value();                                                      \
+    }                                                                          \
+    auto &context = I.getContext();                                            \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    auto *metadata =                                                           \
+        llvm::MDTuple::get(context, llvm::ArrayRef<llvm::Metadata *>({}));     \
+    I.setMetadata(tag, metadata);                                              \
+    return CLASS(*metadata);                                                   \
+  }                                                                            \
+  template <>                                                                  \
+  bool Metadata::remove<CLASS>(llvm::Instruction & I) {                        \
+    auto tag = get_metadata_tag(MetadataKind::ENUM);                           \
+    I.setMetadata(tag, nullptr);                                               \
+    return true;                                                               \
   }
+#include "memoir/utility/Metadata.def"
 
-  // Otherwise, search the tuple for the key we are inserting.
-  auto &current_md_tuple =
-      MEMOIR_SANITIZE(dyn_cast<llvm::MDTuple>(current_md),
-                      "Trying to remove metadata from a non-tuple Metadata");
-  bool removed = true;
-  std::vector<llvm::Metadata *> new_operands = {};
-  for (auto &operand : current_md_tuple.operands()) {
-    auto *operand_md = operand.get();
-    auto *operand_md_string = dyn_cast_or_null<llvm::MDString>(operand_md);
-    MEMOIR_NULL_CHECK(operand_md_string, "MDTuple contains non-MDString");
-    if (operand_md_string->getString().str() != value) {
-      new_operands.push_back(operand_md_string);
-    } else {
-      removed = true;
-    }
-  }
-
-  // If we removed something, change the metadata attached to the string.
-  if (removed) {
-    auto *md_tuple = llvm::MDTuple::getDistinct(
-        Context,
-        llvm::ArrayRef<llvm::Metadata *>(new_operands.data(),
-                                         new_operands.size()));
-    F.setMetadata(kind, md_tuple);
-  }
-
-  return;
+llvm::MDTuple &Metadata::getMetadata() const {
+  return *this->md;
 }
 
-bool MetadataManager::hasMetadata(llvm::Function &F, std::string kind) {
-  return (F.getMetadata(kind) != nullptr);
-}
-
-llvm::Value *MetadataManager::getMetadata(llvm::Function &F, std::string kind) {
-
-  // Find the metadata of the given kind.
-  auto *mdNode = F.getMetadata(kind);
-  if (mdNode == nullptr) {
-    return nullptr;
-  }
-
-  // Get the ValueAsMetadata from the tuple.
-  if (mdNode->getNumOperands() < 2) {
-    return nullptr;
-  }
-  auto *mdValue = mdNode->getOperand(1).get();
-  if (mdValue == nullptr) {
-    return nullptr;
-  }
-
-  // Unpack the ValueAsMetadata.
-  auto mdValueAsMetadata = dyn_cast<llvm::ValueAsMetadata>(mdValue);
-  if (!mdValueAsMetadata) {
-    return nullptr;
-  }
-  auto *value = mdValueAsMetadata->getValue();
-
-  // Return it.
-  return value;
-}
-
-//// Instruction metadata.
-void MetadataManager::setMetadata(llvm::Instruction &I, std::string kind) {
-  /*
-   * Create the metadata
-   */
-  auto &Context = I.getContext();
-  auto mdString = llvm::MDString::get(Context, kind);
-  auto mdNode =
-      llvm::MDNode::get(Context, ArrayRef<llvm::Metadata *>({ mdString }));
-
-  /*
-   * Attach the metadata to the function
-   */
-  I.setMetadata(kind, mdNode);
-
-  return;
-}
-
-void MetadataManager::setMetadata(llvm::Instruction &I,
-                                  std::string kind,
-                                  llvm::Value *value) {
-  // Create the metadata
-  auto &Context = I.getContext();
-  auto *mdString = llvm::MDString::get(Context, kind);
-  auto *mdValue = llvm::ValueAsMetadata::get(value);
-  auto *mdNode =
-      llvm::MDNode::get(Context,
-                        ArrayRef<llvm::Metadata *>({ mdString, mdValue }));
-
-  // Attach the metadata to the function
-  I.setMetadata(kind, mdNode);
-
-  return;
-}
-
-void MetadataManager::insertMetadata(llvm::Instruction &I,
-                                     std::string kind,
-                                     std::string value) {
-  // Get the context.
-  auto &Context = I.getContext();
-
-  // Get the current metadata node.
-  auto *current_md = I.getMetadata(kind);
-
-  // If there isn't a metadata there yet, create it.
-  if (current_md == nullptr) {
-    auto *md_string = llvm::MDString::get(Context, value);
-    auto *md_tuple =
-        llvm::MDTuple::getDistinct(Context,
-                                   ArrayRef<llvm::Metadata *>(md_string));
-    I.setMetadata(kind, md_tuple);
-    return;
-  }
-
-  // Otherwise, search the tuple for the key we are inserting.
-  auto &current_md_tuple =
-      MEMOIR_SANITIZE(dyn_cast<llvm::MDTuple>(current_md),
-                      "Trying to insert metadata to a non-tuple Metadata");
-  for (auto &operand : current_md_tuple.operands()) {
-    auto *operand_md = operand.get();
-    auto *operand_md_string = dyn_cast_or_null<llvm::MDString>(operand_md);
-    MEMOIR_NULL_CHECK(operand_md_string, "MDTuple contains non-MDString");
-    if (operand_md_string->getString().str() == value) {
-      return;
-    }
-  }
-
-  // If we didn't find the key, create and push the metadata onto the tuple.
-  auto *md_string = llvm::MDString::get(Context, value);
-  vector<llvm::Metadata *> new_operands(current_md_tuple.op_begin(),
-                                        current_md_tuple.op_end());
-  new_operands.push_back(md_string);
-  auto *new_md_tuple = llvm::MDTuple::getDistinct(Context, new_operands);
-  I.setMetadata(kind, new_md_tuple);
-
-  return;
-}
-
-void MetadataManager::removeMetadata(llvm::Instruction &I,
-                                     std::string kind,
-                                     std::string value) {
-  // Get the context.
-  auto &Context = I.getContext();
-
-  // Get the current metadata node.
-  auto *current_md = I.getMetadata(kind);
-
-  // If there isn't a metadata there yet, we're done.
-  if (current_md == nullptr) {
-    return;
-  }
-
-  // Otherwise, search the tuple for the key we are inserting.
-  auto &current_md_tuple =
-      MEMOIR_SANITIZE(dyn_cast<llvm::MDTuple>(current_md),
-                      "Trying to remove metadata from a non-tuple Metadata");
-  bool removed = true;
-  std::vector<llvm::Metadata *> new_operands = {};
-  for (auto &operand : current_md_tuple.operands()) {
-    auto *operand_md = operand.get();
-    auto *operand_md_string = dyn_cast_or_null<llvm::MDString>(operand_md);
-    MEMOIR_NULL_CHECK(operand_md_string, "MDTuple contains non-MDString");
-    if (operand_md_string->getString().str() != value) {
-      new_operands.push_back(operand_md_string);
-    } else {
-      removed = true;
-    }
-  }
-
-  // If we removed something, change the metadata attached to the string.
-  if (removed) {
-    auto *md_tuple = llvm::MDTuple::getDistinct(
-        Context,
-        llvm::ArrayRef<llvm::Metadata *>(new_operands.data(),
-                                         new_operands.size()));
-    I.setMetadata(kind, md_tuple);
-  }
-
-  return;
-}
-bool MetadataManager::hasMetadata(llvm::Instruction &I, std::string kind) {
-  return (I.getMetadata(kind) != nullptr);
-}
-
-llvm::Value *MetadataManager::getMetadata(llvm::Instruction &I,
-                                          std::string kind) {
-  // Find the metadata of the given kind.
-  auto *mdNode = I.getMetadata(kind);
-  if (mdNode == nullptr) {
-    return nullptr;
-  }
-
-  // Get the ValueAsMetadata from the tuple.
-  if (mdNode->getNumOperands() < 2) {
-    return nullptr;
-  }
-  auto *mdValue = mdNode->getOperand(1).get();
-  if (mdValue == nullptr) {
-    return nullptr;
-  }
-
-  // Unpack the ValueAsMetadata.
-  auto mdValueAsMetadata = dyn_cast<llvm::ValueAsMetadata>(mdValue);
-  if (!mdValueAsMetadata) {
-    return nullptr;
-  }
-  auto *value = mdValueAsMetadata->getValue();
-
-  // Return it.
-  return value;
-}
-
-} // namespace memoir
-} // namespace llvm
+} // namespace llvm::memoir

--- a/runtime/include/memoir.h
+++ b/runtime/include/memoir.h
@@ -339,7 +339,8 @@ collection_ref MEMOIR_FUNC(argPHI)(const collection_ref collection);
 __IMMUT_ATTR
 __ALLOC_ATTR
 __RUNTIME_ATTR
-collection_ref MEMOIR_FUNC(retPHI)(const collection_ref collection);
+collection_ref MEMOIR_FUNC(retPHI)(const collection_ref collection,
+                                   void *function);
 
 // Type checking and function signatures.
 __RUNTIME_ATTR

--- a/runtime/src/ssa_operations.cpp
+++ b/runtime/src/ssa_operations.cpp
@@ -38,7 +38,7 @@ collection_ref MEMOIR_FUNC(argPHI)(const collection_ref in) {
 __IMMUT_ATTR
 __ALLOC_ATTR
 __RUNTIME_ATTR
-collection_ref MEMOIR_FUNC(retPHI)(const collection_ref in) {
+collection_ref MEMOIR_FUNC(retPHI)(const collection_ref in, void *function) {
   return in;
 }
 

--- a/tests/unit/fold/main.cpp
+++ b/tests/unit/fold/main.cpp
@@ -27,6 +27,22 @@ uint32_t sum_seq_times_mut(uint32_t accum, size_t i, uint32_t v, uint32_t *x) {
   return accum + v * ((*x)++);
 }
 
+uint32_t sum_seq_mut_set(uint32_t accum,
+                         size_t i,
+                         uint32_t v,
+                         collection_ref seen) {
+  memoir_assert_collection_type(memoir_assoc_type(memoir_u32_t, memoir_void_t),
+                                seen);
+
+  if (memoir_assoc_has(seen, v)) {
+    return accum;
+  } else {
+    memoir_assoc_insert(seen, v);
+  }
+
+  return accum + v;
+}
+
 uint32_t sum_assoc(uint32_t accum, uint32_t k, uint32_t v) {
   return accum + k + v;
 }
@@ -82,7 +98,7 @@ int main() {
   }
 
   TEST(fold_set) {
-    auto set = memoir_allocate_assoc_array(memoir_u32_t, memoir_u32_t);
+    auto set = memoir_allocate_assoc_array(memoir_u32_t, memoir_void_t);
 
     memoir_assoc_insert(set, 10);
     memoir_assoc_insert(set, 20);
@@ -155,9 +171,21 @@ int main() {
 
     auto sum = memoir_fold(u32, 0, seq, sum_seq_times_mut, &x);
 
-    printf("%u", x);
-
     EXPECT(sum == (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10), "Sum incorrect!");
     EXPECT(x == 11, "x incorrect!");
+  }
+
+  TEST(close_mut_collection) {
+    auto seq = memoir_allocate_sequence(memoir_u32_t, 10);
+
+    for (size_t i = 0; i < 10; ++i) {
+      memoir_index_write(u32, i % 5, seq, i);
+    }
+
+    auto set = memoir_allocate_assoc(memoir_u32_t, memoir_void_t);
+
+    auto sum = memoir_fold(u32, 0, seq, sum_seq_mut_set, set);
+
+    EXPECT(sum == (0 + 1 + 2 + 3 + 4), "Sum incorrect!");
   }
 }

--- a/tests/unit/fold/main.cpp
+++ b/tests/unit/fold/main.cpp
@@ -178,14 +178,16 @@ int main() {
   TEST(close_mut_collection) {
     auto seq = memoir_allocate_sequence(memoir_u32_t, 10);
 
-    for (size_t i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < 9; ++i) {
       memoir_index_write(u32, i % 5, seq, i);
     }
+    memoir_index_write(u32, 5, seq, 9);
 
     auto set = memoir_allocate_assoc(memoir_u32_t, memoir_void_t);
 
     auto sum = memoir_fold(u32, 0, seq, sum_seq_mut_set, set);
 
-    EXPECT(sum == (0 + 1 + 2 + 3 + 4), "Sum incorrect!");
+    EXPECT(sum == (0 + 1 + 2 + 3 + 4 + 5), "Sum incorrect!");
+    EXPECT(memoir_size(set) == 6, "Size incorrect!");
   }
 }


### PR DESCRIPTION
Adds RetPHI instructions at call sites
Adds metadata for live-out values inside of the function
Creates a new InlineFunction method to handle RetPHIs
Updates the LowerFold pass to manage RetPHI instructions and also inline the call.

Closes #81, with addendum: parameters are not specified as inout, every variable is. Call by value must be implemented explicitly. 